### PR TITLE
Remove global command for leader/loser boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ to take away a point. A few additional features have been built in (see below), 
 - `@jake==`: get the current number of points a user or thing has
 - `@pluspl.us leaderboard`: get (up to) 10 of the top users and things
 - `@pluspl.us loserboard`: get (up to) 10 of the bottom users and things
-- `@pluspl.us leaderboard global`: get (up to) 10 of the top things across all teams
-- `@pluspl.us loserboard global`: get (up to) 10 of the bottom things across all teams
 - `@pluspl.us reset`: permanently removes all points from a Slack team
 - `@pluspl.us help`: get a list of the available commands from within Slack
 
 
 ### Support
 
-Support this project on [Patreon](https://www.patreon.com/plpl) or [Buy me a Coffee](https://www.buymeacoffee.com/jhc). Contributions go towards hosting this app so that anyone can freely install it from the [Slack app store](https://www.slack.com/apps/AJ7NX3XFH-plusplus). 
+Support this project on [Patreon](https://www.patreon.com/plpl) or [Buy me a Coffee](https://www.buymeacoffee.com/jhc). Contributions go towards hosting this app so that anyone can freely install it from the [Slack app store](https://www.slack.com/apps/AJ7NX3XFH-plusplus).
 
 
 ### Install Instructions

--- a/plusplus/operations/help.py
+++ b/plusplus/operations/help.py
@@ -10,8 +10,6 @@ def help_text(team):
                 "• *#(thing)==*: get current point total of a thing (e.g. #jake==)",
                 "• *{ping} leaderboard*: get the current high scoring people and things",
                 "• *{ping} loserboard*: get the current low scoring people and things",
-                "• *{ping} leaderboard global*: get the current high scoring things across all teams",
-                "• *{ping} loserboard global*: get the current low scoring things across all teams",
                 "• *{ping} reset*: resets the local leaderboard to 0",
                 "• *{ping} feedback <feedback>*: send feedback about this bot to its wrangler"]
     formatted_commands = list()

--- a/plusplus/operations/slack_handler.py
+++ b/plusplus/operations/slack_handler.py
@@ -86,19 +86,17 @@ def process_incoming_message(event_data, req):
         post_message(message, team, channel, thread_ts)
         print("Processed " + thing.item)
     elif "leaderboard" in message and team.bot_user_id.lower() in message:
-        global_board = "global" in message
         team.slack_client().api_call(
             "chat.postMessage",
             channel=channel,
-            blocks=generate_leaderboard(team=team, global_leaderboard=global_board)
+            blocks=generate_leaderboard(team=team)
         )
         print("Processed leaderboard for team " + team.id)
     elif "loserboard" in message and team.bot_user_id.lower() in message:
-        global_board = "global" in message
         team.slack_client().api_call(
             "chat.postMessage",
             channel=channel,
-            blocks=generate_leaderboard(team=team, losers=True, global_leaderboard=global_board)
+            blocks=generate_leaderboard(team=team, losers=True)
         )
         print("Processed loserboard for team " + team.id)
     elif "help" in message and (team.bot_user_id.lower() in message or channel_type == "im"):


### PR DESCRIPTION
Global leaderboards/loserboards aren't used much, and don't function correctly. This change removes that feature. 

Closes #23