### PR TITLE
Update slackclient to the newest version

### DIFF
--- a/plusplus/config.py
+++ b/plusplus/config.py
@@ -4,7 +4,8 @@ VERSION = 0.1
 NAME = os.environ.get("NAME")
 SLACK_CLIENT_ID = os.environ.get('SLACK_CLIENT_ID')
 SLACK_CLIENT_SECRET = os.environ.get('SLACK_CLIENT_SECRET')
-SLACK_OAUTH_URL = f"https://slack.com/oauth/authorize?client_id={SLACK_CLIENT_ID}&scope=bot"
+SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,team:read,users:read,users:write"
+SLACK_OAUTH_URL = f"https://slack.com/oauth/v2/authorize?client_id={SLACK_CLIENT_ID}&scope={SLACK_SCOPES}"
 SLACK_SIGNING_SECRET = os.environ.get('SLACK_SIGNING_SECRET')
 SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
 SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/plusplus/models.py
+++ b/plusplus/models.py
@@ -1,5 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
-from slackclient import SlackClient
+from from slack import WebClient
 import datetime
 
 db = SQLAlchemy()
@@ -26,15 +26,16 @@ class SlackTeam(db.Model):
         self.bot_access_token = request_json['bot']['bot_access_token']
         self.get_team_metadata()
 
+    @property
     def slack_client(self):
-        return SlackClient(self.bot_access_token)
+        return WebClient(self.bot_access_token)
 
     def update_last_access(self):
         self.last_request = datetime.datetime.utcnow()
 
     def get_team_metadata(self):
         sc = self.slack_client()
-        response = sc.api_call("team.info")
+        response = sc.team_info()
         self.team_name = response['team']['name']
         self.team_domain = f"https://{response['team']['domain']}.slack.com"
         self.team_email_domain = response['team']['email_domain']

--- a/plusplus/models.py
+++ b/plusplus/models.py
@@ -1,5 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
-from from slack import WebClient
+from slack import WebClient
 import datetime
 
 db = SQLAlchemy()

--- a/plusplus/models.py
+++ b/plusplus/models.py
@@ -21,9 +21,9 @@ class SlackTeam(db.Model):
         self.update(request_json)
 
     def update(self, request_json):
-        self.id = request_json['team_id']
-        self.bot_user_id = request_json['bot']['bot_user_id']
-        self.bot_access_token = request_json['bot']['bot_access_token']
+        self.id = request_json['team']['id']
+        self.bot_user_id = request_json['bot_user_id']
+        self.bot_access_token = request_json['access_token']
         self.get_team_metadata()
 
     @property

--- a/plusplus/models.py
+++ b/plusplus/models.py
@@ -34,7 +34,7 @@ class SlackTeam(db.Model):
         self.last_request = datetime.datetime.utcnow()
 
     def get_team_metadata(self):
-        sc = self.slack_client()
+        sc = self.slack_client
         response = sc.team_info()
         self.team_name = response['team']['name']
         self.team_domain = f"https://{response['team']['domain']}.slack.com"

--- a/plusplus/operations/slack_handler.py
+++ b/plusplus/operations/slack_handler.py
@@ -13,15 +13,13 @@ thing_exp = re.compile(r"#([A-Za-z0-9\.\-_@$!\*\(\)\,\?\/%\\\^&\[\]\{\"':; ]+)(\
 
 def post_message(message, team, channel, thread_ts=None):
     if thread_ts:
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             text=message,
             thread_ts=thread_ts
         )
     else:
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             text=message
         )
@@ -87,36 +85,31 @@ def process_incoming_message(event_data):
         post_message(message, team, channel, thread_ts)
         print("Processed " + thing.item)
     elif "leaderboard" in message and team.bot_user_id.lower() in message:
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             blocks=generate_leaderboard(team=team)
         )
         print("Processed leaderboard for team " + team.id)
     elif "loserboard" in message and team.bot_user_id.lower() in message:
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             blocks=generate_leaderboard(team=team, losers=True)
         )
         print("Processed loserboard for team " + team.id)
     elif "help" in message and (team.bot_user_id.lower() in message or channel_type == "im"):
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             blocks=help_text(team)
         )
         print("Processed help for team " + team.id)
     elif "feedback" in message and (team.bot_user_id.lower() in message or channel_type == "im"):
         print(message)
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             text="Thanks! For a more urgent response, please email " + config.SUPPORT_EMAIL
         )
     elif "reset" in message and team.bot_user_id.lower() in message:
-        team.slack_client().api_call(
-            "chat.postMessage",
+        team.slack_client.chat_postMessage(
             channel=channel,
             blocks=generate_reset_block()
         )

--- a/plusplus/slack.py
+++ b/plusplus/slack.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, abort, request, redirect
 from flask import current_app as app
-from slackclient import SlackClient
+from slack import WebClient
 from plusplus.models import db, SlackTeam, Thing
 from sqlalchemy.exc import IntegrityError
 from plusplus import config

--- a/plusplus/slack.py
+++ b/plusplus/slack.py
@@ -23,7 +23,7 @@ def callback():
     auth_code = request.args['code']
 
     # An empty string is a valid token for this request
-    sc = SlackClient("")
+    sc = WebClient("")
 
     # Request the auth tokens from Slack
     data = sc.api_call(

--- a/plusplus/slack.py
+++ b/plusplus/slack.py
@@ -26,8 +26,7 @@ def callback():
     sc = WebClient("")
 
     # Request the auth tokens from Slack
-    data = sc.api_call(
-        "oauth.access",
+    data = sc.oauth_v2_access(
         client_id=app.config['SLACK_CLIENT_ID'],
         client_secret=app.config['SLACK_CLIENT_SECRET'],
         code=auth_code

--- a/plusplus/slack.py
+++ b/plusplus/slack.py
@@ -43,7 +43,7 @@ def callback():
         print("Created team " + team.id)
     except IntegrityError:
         db.session().rollback()
-        team = SlackTeam.query.filter_by(id=data[['team']['id']).first()
+        team = SlackTeam.query.filter_by(id=data['team']['id']).first()
         team.update(data)
         db.session.add(team)
         db.session.commit()

--- a/plusplus/slack.py
+++ b/plusplus/slack.py
@@ -43,7 +43,7 @@ def callback():
         print("Created team " + team.id)
     except IntegrityError:
         db.session().rollback()
-        team = SlackTeam.query.filter_by(id=data['team_id']).first()
+        team = SlackTeam.query.filter_by(id=data[['team']['id']).first()
         team.update(data)
         db.session.add(team)
         db.session.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pyee==6.0.0
 requests==2.24.0
 sentry-sdk==0.14.4
 six==1.15.0
-slackclient==1.3.1
+slackclient==2.9.3
 slackeventsapi==2.2.1
 SQLAlchemy==1.3.20
 urllib3==1.25.11


### PR DESCRIPTION
This also adds support for Slack OAuth v2 (which is the only supported version with slackclient v2). This PR should not be merged until Slack updated the App Store entry to add the scopes requested. 

Closes #22