### PR TITLE
Add the missing scopes for private groups

### DIFF
--- a/plusplus/config.py
+++ b/plusplus/config.py
@@ -4,7 +4,7 @@ VERSION = 0.1
 NAME = os.environ.get("NAME")
 SLACK_CLIENT_ID = os.environ.get('SLACK_CLIENT_ID')
 SLACK_CLIENT_SECRET = os.environ.get('SLACK_CLIENT_SECRET')
-SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,mpim:write,team:read,channels:history,app_mentions:read"
+SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,mpim:write,team:read,channels:history,app_mentions:read,groups:history,groups:read,groups:write"
 SLACK_OAUTH_URL = f"https://slack.com/oauth/v2/authorize?client_id={SLACK_CLIENT_ID}&scope={SLACK_SCOPES}"
 SLACK_SIGNING_SECRET = os.environ.get('SLACK_SIGNING_SECRET')
 SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')

--- a/plusplus/config.py
+++ b/plusplus/config.py
@@ -4,7 +4,7 @@ VERSION = 0.1
 NAME = os.environ.get("NAME")
 SLACK_CLIENT_ID = os.environ.get('SLACK_CLIENT_ID')
 SLACK_CLIENT_SECRET = os.environ.get('SLACK_CLIENT_SECRET')
-SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,mpim:write,team:read,channels:history,app_mentions:read,groups:history,groups:read,groups:write" # noqa: E501
+SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,mpim:write,team:read,channels:history,app_mentions:read,groups:history,groups:read,groups:write"  # noqa: E501
 SLACK_OAUTH_URL = f"https://slack.com/oauth/v2/authorize?client_id={SLACK_CLIENT_ID}&scope={SLACK_SCOPES}"
 SLACK_SIGNING_SECRET = os.environ.get('SLACK_SIGNING_SECRET')
 SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')

--- a/plusplus/config.py
+++ b/plusplus/config.py
@@ -4,7 +4,7 @@ VERSION = 0.1
 NAME = os.environ.get("NAME")
 SLACK_CLIENT_ID = os.environ.get('SLACK_CLIENT_ID')
 SLACK_CLIENT_SECRET = os.environ.get('SLACK_CLIENT_SECRET')
-SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,mpim:write,team:read,channels:history,app_mentions:read,groups:history,groups:read,groups:write"
+SLACK_SCOPES = "chat:write,im:history,im:write,mpim:history,mpim:write,team:read,channels:history,app_mentions:read,groups:history,groups:read,groups:write" # noqa: E501
 SLACK_OAUTH_URL = f"https://slack.com/oauth/v2/authorize?client_id={SLACK_CLIENT_ID}&scope={SLACK_SCOPES}"
 SLACK_SIGNING_SECRET = os.environ.get('SLACK_SIGNING_SECRET')
 SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ Jinja2==2.11.2
 markdown==3.3.3
 MarkupSafe==1.1.1
 psycopg2==2.8.6
-pyee==6.0.0
 requests==2.24.0
 sentry-sdk==0.14.4
 six==1.15.0


### PR DESCRIPTION
This fixes #151 by adding missing `groups:history,groups:read,groups:write` scopes. Do not merge until Slack approves the changes on their end. 